### PR TITLE
Add link hover effect, enlarge page link size

### DIFF
--- a/assets/css/keen-dashboards.css
+++ b/assets/css/keen-dashboards.css
@@ -8,8 +8,8 @@ body.application {
   padding: 60px 20px 0;
 }
 body.application > .container-fluid {
-  padding-left: 0px;
-  padding-right: 0px;
+  padding-left: 0;
+  padding-right: 0;
 }
 body.application div[class^="col-"] {
   padding-left: 5px;
@@ -26,7 +26,6 @@ body.application hr {
 }
 
 
-
 .navbar-inverse {
   background-color: #3d4a57;
   border-color: #333;
@@ -34,6 +33,18 @@ body.application hr {
 .navbar-inverse .navbar-nav > li > a,
 .navbar a.navbar-brand {
   color: #fbfbfb;
+  text-decoration: none;
+}
+
+.main-nav > li > a:hover {
+  border-bottom: 2px solid transparent;
+  -webkit-transition: border 300ms ease;
+  -o-transition: border 300ms ease;
+  transition: border 300ms ease;
+  border-bottom-color: white;
+}
+
+.return-link, .return-link:focus, .return-link:hover {
   text-decoration: none;
 }
 

--- a/assets/css/keen-static.css
+++ b/assets/css/keen-static.css
@@ -151,5 +151,5 @@ h3 {
 }
 
 .love p {
-  margin-bottom: 0px;
+  margin-bottom: 0;
 }

--- a/examples/index.html
+++ b/examples/index.html
@@ -11,7 +11,7 @@
 
   <div class="masthead">
     <div class="container">
-      <h1><a href="../"><small class="glyphicon glyphicon-chevron-left"></small></a> Examples</h1>
+      <h1><a class="return-link" href="../"><small class="glyphicon glyphicon-chevron-left"></small> Examples</a></h1>
     </div>
   </div>
 

--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
           </a>
         </div>
         <nav class="navbar-collapse collapse keen-navbar-collapse" role="navigation">
-          <ul class="nav navbar-nav">
+          <ul class="nav navbar-nav main-nav">
             <li><a href="https://keen.io/blog/101269629091/charts-on-grids-responsive-dashboard-templates-with" target="_blank">About</a></li>
             <li><a href="https://keen.io/team" target="_blank">Team</a></li>
             <li><a href="https://groups.google.com/forum/#!forum/keen-io-devs" target="_blank">Community</a></li>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -11,7 +11,7 @@
 
   <div class="masthead">
     <div class="container">
-      <h1><a href="../"><small class="glyphicon glyphicon-chevron-left"></small></a> Layouts</h1>
+      <h1><a class="return-link" href="../"><small class="glyphicon glyphicon-chevron-left"></small> Layouts</a></h1>
     </div>
   </div>
 


### PR DESCRIPTION
This pull request ensures that a hover effect is present, when links in the top nav-bar are selected, so that page transitioning is more seamless. This also enhances page accessibility.

The effects look something like the following:
![keen](https://cloud.githubusercontent.com/assets/3946887/5311667/107ee6b4-7c96-11e4-8d3d-6baf6398da06.png)

The clickable area of the "return" links on both the examples and layouts page have been enlarged, so that users may now click the link text in order to return to the previous page.

Thanks for creating these dashboard templates!
psgs :palm_tree: 