### PR TITLE
Adds a package.json and .npmignore for npm deployment

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+demo-data/
+examples/
+layouts/
+assets/lib/

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+    "name": "keen-dashboards",
+    "version": "0.1.0",
+    "description": "Responsive dashboard templates for Bootstrap",
+    "main": "./assets/css/keen-dashboards.css",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/keen/dashboards.git"
+    },
+    "keywords": [
+        "keen io",
+        "dashboards",
+        "dataviz",
+        "visualization"
+    ],
+    "author": "Dustin Larimer <dustin@keen.io>",
+    "license": "MIT",
+    "bugs": {
+        "url": "https://github.com/keen/dashboards/issues"
+    },
+    "homepage": "https://github.com/keen/dashboards#readme"
+}


### PR DESCRIPTION
Awesome work on this project, thanks a lot!

It would be really helpful if you could merge this **and deploy the package to npm** (the keen-dashboards name is available).

A lot of people are now using webpack or other module bundlers, and rely on npm for their dependencies. Not having a package.json forces us to use bower, or write custom scripts to pull the source from github.

Looking forward to your feedback.

